### PR TITLE
Tell users SMS is not secure

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -12,6 +12,7 @@
 
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane active" id="verification-tab">
+        <p>Please note: As phone numbers are not managed by your IT team, Fliplet recommends Email verification for secure apps.</p>
         <div id="validation"></div>
       </div>
 


### PR DESCRIPTION
Note, this is untested but important so people understand that SMS is less secure than SMS as, unlike email, IT do not control sms security centrally.