### PR TITLE
When user enters email, input for verification code will be focused automatically

### DIFF
--- a/build.html
+++ b/build.html
@@ -24,7 +24,7 @@
       <h2>Verify your email address</h2>
       <p>Enter the verification code that was sent to the phone number associated with <span class="input-email">\{{ storedEmail }}</span>.</p>
       <div class="form-group input-wrapper" v-bind:class="{ 'has-error': codeError}">
-        <input type="tel" v-model="code" class="verify_pin form-control" placeholder="Enter verification code">
+        <input type="tel" v-model="code" class="verify_pin form-control" ref="verificationCode" placeholder="Enter verification code">
         <span v-on:click="back" class="fa fa-chevron-left back"></span>
       </div>
       <p class="pin-error text-danger">You entered the wrong verification code or it might have expired.

--- a/js/build.js
+++ b/js/build.js
@@ -189,6 +189,7 @@ Fliplet().then(function() {
           vmData.auth = false;
           vmData.verifyCode = true;
           vmData.emailError = false;
+          this.$refs.verificationCode.select();
         },
         haveCode: function() {
           Fliplet.Analytics.trackEvent({


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#2571

## Description
Added ref for verification input. After the verification window opens, verification input will be focused automatically.

## Screenshots/screencasts
![verification demo](https://user-images.githubusercontent.com/52824207/65497866-9d445180-dec3-11e9-9154-2e577655ca84.gif)

## Backward compatibility
This change is fully backward compatible.